### PR TITLE
Include a flies property in package.json so we don't leak build details.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
Not a big deal but probably not great to include our github actions files and other unneeded files in the package. This ensures that only the dist/ folder along with the package.json get included in the published package. 

Before:
<img width="659" alt="Screenshot 2025-02-13 at 1 50 34 PM" src="https://github.com/user-attachments/assets/ce9fefad-2f34-465d-8ae5-316cc2dfa878" />

After:
<img width="659" alt="Screenshot 2025-02-13 at 1 47 08 PM" src="https://github.com/user-attachments/assets/a643a2ea-9b98-4218-a5fa-8c0fc6166401" />
